### PR TITLE
adding junit-jupiter-params for @ParameterizedTest support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 dependency-reduced-pom.xml
 .okhttpcache
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>


### PR DESCRIPTION
It's possible I'm missing something, but in order to add a `@ParameterizedTest` to the SpoolDir connector I needed this dependency.