### PR TITLE
MINOR: pin jackson version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <kafka.version>2.4.0</kafka.version>
         <guava.version>28.2-jre</guava.version>
         <reflections.version>0.9.11</reflections.version>
-        <jackson.version>[2.9.8,)</jackson.version>
+        <jackson.version>2.12.0</jackson.version>
         <connect-utils.version>[0.4.33,0.4.1000)</connect-utils.version>
         <kafka-connect-style.version>[1.1.0.0,1.1.0.1000)</kafka-connect-style.version>
         <confluent.packaging.plugin.version>[0.9.0,0.9.100)</confluent.packaging.plugin.version>


### PR DESCRIPTION
Using a range for jackson version is causing some customers using connectors dependent on this parent pom to use whatever jackson dependency they have instead of getting the latest. I think it would be better and cleaner to pin this dependency version.

Signed-off-by: Aakash Shah <ashah@confluent.io>