### PR TITLE
Update Kafka parent build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,8 +8,12 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   verify:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,3 +28,68 @@ jobs:
 
       - name: Verify
         run: mvn -B clean verify
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java and Maven Central credentials
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Read Maven version
+        id: release_version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_version="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+          if [[ -z "${release_version}" ]]; then
+            echo "Root project version is empty." >&2
+            exit 1
+          fi
+          if [[ "${release_version}" == *-SNAPSHOT ]]; then
+            echo "Root project version must not be a snapshot. Found: ${release_version}" >&2
+            exit 1
+          fi
+
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/${release_version}" >/dev/null; then
+            echo "Release tag ${release_version} already exists." >&2
+            exit 1
+          fi
+
+          echo "version=${release_version}" >> "${GITHUB_OUTPUT}"
+          echo "Release version: ${release_version}"
+
+      - name: Deploy to Maven Central
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
+        run: mvn -B -Pmaven-central -Dgpg.keyname="${GPG_KEYNAME}" clean deploy
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.release_version.outputs.version }}" \
+            --target "${GITHUB_SHA}" \
+            --title "${{ steps.release_version.outputs.version }}" \
+            --generate-notes

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,26 @@
+name: Maven
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Verify
+        run: mvn -B clean verify

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,0 @@
-#!groovy
-@Library('jenkins-pipeline') import com.github.jcustenborder.jenkins.pipeline.MavenCentralPipeline
-
-def pipe = new MavenCentralPipeline()
-pipe.execute()

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>com.github.jcustenborder.kafka.connect</groupId>
     <artifactId>kafka-connect-parent</artifactId>
-    <version>3.3.1-1</version>
+    <version>4.3.1-1</version>
     <packaging>pom</packaging>
     <name>kafka-connect-parent</name>
     <inceptionYear>2017</inceptionYear>
@@ -35,8 +35,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <kafka.version>3.3.1</kafka.version>
-        <connect-utils.version>[0.7.166,0.7.2000)</connect-utils.version>
+        <kafka.version>4.3.1</kafka.version>
+        <connect-utils.version>[0.8.0,0.8.2000)</connect-utils.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
         <kafka-connect-style.version>[1.1.0,1.1.1000)</kafka-connect-style.version>
         <confluent.hub.packaging.version>0.12.0</confluent.hub.packaging.version>
         <mockito.version>4.8.0</mockito.version>
@@ -98,6 +99,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
             <dependency>
                 <groupId>com.github.jcustenborder.kafka.connect</groupId>
@@ -141,12 +149,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.jcustenborder</groupId>
-            <artifactId>docker-compose-junit-extension</artifactId>
-            <version>[0.1.4, 0.1.1000)</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.jcustenborder.kafka.connect</groupId>
             <artifactId>connect-utils-testing</artifactId>
             <version>${connect-utils.version}</version>
@@ -171,6 +173,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-kafka</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -238,7 +250,7 @@
                                     <version>3.5.0</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>1.8</version>
+                                    <version>17</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -248,11 +260,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <inherited>true</inherited>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
- upgrade the parent POM to Kafka 4.3.1, connect-utils 0.8.x, and Java 17
- replace the Docker Compose JUnit extension dependency with Testcontainers 2.0.5 dependencies
- replace Jenkins with GitHub Actions Maven verification and release automation
- release pushes to master by reading the static release version from `pom.xml` `project.version`

Closes #44
Closes #45
Closes #46
Closes #43

## Verification
- mvn -U -B clean verify
- mvn -B clean verify
- mvn -q -DforceStdout help:evaluate -Dexpression=project.version
- mvn -q -DforceStdout help:evaluate -Dexpression=kafka.version
- mvn -q -DforceStdout help:evaluate -Dexpression=connect-utils.version
- mvn -q -DforceStdout help:evaluate -Dexpression=testcontainers.version
- mvn -B dependency:tree -Dincludes=org.testcontainers,com.github.jcustenborder:docker-compose-junit-extension
- workflow YAML parsed locally
- gh pr checks 47 --watch --interval 10

Note: actionlint is not installed locally, so workflow syntax was checked with Ruby YAML parsing instead.