### PR TITLE
Fix Maven Central release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@
                                 </goals>
                                 <configuration>
                                     <keyname>${gpg.keyname}</keyname>
-                                    <passphraseServerId>${gpg.keyname}</passphraseServerId>
+                                    <passphraseServerId>gpg.passphrase</passphraseServerId>
                                     <gpgArguments>
                                         <arg>--pinentry-mode</arg>
                                         <arg>loopback</arg>
@@ -538,38 +538,24 @@
                         </executions>
                     </plugin>
                     <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.6.7</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>oss.sonatype.org</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <description>${project.version}</description>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>deploy-to-sonatype</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>deploy</goal>
-                                    <goal>release</goal>
-                                </goals>
-                            </execution>
-                        </executions>
+                        <extensions>false</extensions>
                     </plugin>
                 </plugins>
             </build>
-            <distributionManagement>
-                <repository>
-                    <id>oss.sonatype.org</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-                <snapshotRepository>
-                    <id>oss.sonatype.org</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-            </distributionManagement>
         </profile>
     </profiles>
 


### PR DESCRIPTION
## Summary
- Use the setup-java GPG passphrase server id `gpg.passphrase`.
- Replace old OSSRH/Nexus staging release config with Sonatype Central Publishing using server id `central`.
- Disable the inherited Nexus Staging extension so the parent POM does not inject the old deploy execution.

## Test Plan
- `mvn verify`
- `mvn -B -Pmaven-central -Dgpg.keyname=dummy -Dgpg.skip=true help:effective-pom -Doutput=target/effective-pom.xml`
- `mvn -B --settings <dummy-central-settings> -Pmaven-central -Dgpg.keyname=dummy -Dgpg.skip=true -DskipPublishing=true -DaltDeploymentRepository=local::default::file://$(pwd)/target/deploy-test deploy`